### PR TITLE
Add keyboard navigation for molecule gameplay

### DIFF
--- a/script.js
+++ b/script.js
@@ -83,6 +83,7 @@ let individualGuessStatsTotal = [];
 let individualGuessStatsBlind = [];
 
 let tutorialButton;
+let guessInput;
 
 let gradualHints;
 let changedSettings = false;
@@ -104,6 +105,26 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
     reloadAssets();
     updateFromStorage();
+    
+    guessInput = document.getElementById('guessInput');
+    
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            const settingsDiv = document.getElementById('settings');
+            const tutorialDiv = document.getElementById('tutorial');
+            const statisticsDiv = document.getElementById('statistics');
+            
+            if (settingsDiv.hidden && tutorialDiv.hidden && statisticsDiv.hidden && guessInput.hidden === true) {
+                moleculeNum++;
+                setStorage("moleculeNum", moleculeNum);
+                changedSettings = true;
+                setStorage("changedSettings", true, false);
+                location.reload();
+            }
+        }
+    });
+    
+    guessInput.focus();
 });
 
 function checkStorageSettings() {

--- a/script.js
+++ b/script.js
@@ -905,7 +905,7 @@ function showGuess(fromStorage = false){
 
         const span = document.createElement('span');
         span.className = 'green';
-        span.innerHTML = "<b>Correct!</b>";
+        span.innerHTML = "<b>Correct!</b><br><small>Press Enter for next molecule</small>";
         newDiv.appendChild(span);
         showHint(1);
         showHint(2);


### PR DESCRIPTION
## Summary

Press Enter after a correct guess to advance to the next molecule. Input auto-focuses on page load for seamless keyboard-only gameplay.

## Changes

- Enter key advances to next molecule (after correct guess only)
- Input auto-focused on page load
- Hint message shown after correct guess
- Modals (settings, tutorial, statistics) block Enter.

## Testing
- Manual testing confirms a greatly improved user experience.
- No bugs or regressions noticed.

Resolves #1